### PR TITLE
5/31

### DIFF
--- a/Assets/Animation/AC/PlayerAC.controller
+++ b/Assets/Animation/AC/PlayerAC.controller
@@ -388,6 +388,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
+  - m_Name: useGadget
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: inputForward
     m_Type: 1
     m_DefaultFloat: 0

--- a/Assets/DoorSearchPlayerRight.cs
+++ b/Assets/DoorSearchPlayerRight.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DoorSearchPlayerRight : MonoBehaviour
+{
+    [SerializeField]
+    private doorVariable doorVar;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if(other.tag == "Player")
+            doorVar.SetPlayerRight(true);
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if(other.tag == "Player")
+            doorVar.SetPlayerRight(false);
+    }
+}

--- a/Assets/DoorSearchPlayerRight.cs.meta
+++ b/Assets/DoorSearchPlayerRight.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb099513da30deb448ecdf83ac0fa43d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Nishida_TestScene.unity
+++ b/Assets/Scenes/Nishida_TestScene.unity
@@ -165,10 +165,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Wall Door
       objectReference: {fileID: 0}
-    - target: {fileID: 4790683710122119354, guid: 3cbd2eafe98f3414aba68fe1d0dc1d3a, type: 3}
-      propertyPath: m_TagString
-      value: interact
-      objectReference: {fileID: 0}
     - target: {fileID: 8367886754899993257, guid: 3cbd2eafe98f3414aba68fe1d0dc1d3a, type: 3}
       propertyPath: m_RootOrder
       value: 0
@@ -277,11 +273,6 @@ Transform:
   m_Father: {fileID: 328968856}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &325758085 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 4790683710122119354, guid: 3cbd2eafe98f3414aba68fe1d0dc1d3a, type: 3}
-  m_PrefabInstance: {fileID: 89766680}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &328968856 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 494684043, guid: 1930e7ee83b3e7d479cb7f8c69e6c337, type: 3}
@@ -558,6 +549,10 @@ PrefabInstance:
     - target: {fileID: 4524479840273165841, guid: 1930e7ee83b3e7d479cb7f8c69e6c337, type: 3}
       propertyPath: m_Name
       value: Enemy (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4524479840273165841, guid: 1930e7ee83b3e7d479cb7f8c69e6c337, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1930e7ee83b3e7d479cb7f8c69e6c337, type: 3}
@@ -1107,19 +1102,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8367886754899993257, guid: 3cbd2eafe98f3414aba68fe1d0dc1d3a, type: 3}
   m_PrefabInstance: {fileID: 89766680}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1497331635
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 325758085}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dfe1edbd78b9fe64abe68a6b856e3782, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  doorScopeCenterPos: {x: 0, y: -0.8, z: 0}
 --- !u!1 &1503149979
 GameObject:
   m_ObjectHideFlags: 0
@@ -1187,37 +1169,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 494684043, guid: 1930e7ee83b3e7d479cb7f8c69e6c337, type: 3}
   m_PrefabInstance: {fileID: 1981208390}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1787966133
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1787966134}
-  m_Layer: 9
-  m_Name: GadgetHolder
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1787966134
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787966133}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 923644057}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1920576789
 GameObject:
   m_ObjectHideFlags: 0
@@ -1248,6 +1199,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   initScene: 3
+  gadgetObjects: []
 --- !u!4 &1920576791
 Transform:
   m_ObjectHideFlags: 0
@@ -1745,26 +1697,6 @@ PrefabInstance:
     - target: {fileID: 5651910625854211475, guid: 245f5c0e4059c3949ab7ba3874468284, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7384495091219298950, guid: 245f5c0e4059c3949ab7ba3874468284, type: 3}
-      propertyPath: subCamera
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 7384495091219298950, guid: 245f5c0e4059c3949ab7ba3874468284, type: 3}
-      propertyPath: gadgetHolder
-      value: 
-      objectReference: {fileID: 1787966134}
-    - target: {fileID: 7384495091219298950, guid: 245f5c0e4059c3949ab7ba3874468284, type: 3}
-      propertyPath: debugGadgets.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7384495091219298950, guid: 245f5c0e4059c3949ab7ba3874468284, type: 3}
-      propertyPath: debugGadgets.Array.data[0]
-      value: 
-      objectReference: {fileID: 8371366597903373673, guid: 34b1620bf5ea37d458482d9b02fbfba5, type: 3}
-    - target: {fileID: 7384495092733530306, guid: 245f5c0e4059c3949ab7ba3874468284, type: 3}
-      propertyPath: m_IsActive
-      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 245f5c0e4059c3949ab7ba3874468284, type: 3}

--- a/Assets/_Script/Player/Inventory/Inventory.cs
+++ b/Assets/_Script/Player/Inventory/Inventory.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class Inventory : MonoBehaviour
 {
     public GameObject mainWeapon { get; private set; }
+    public List<GameObject> gadgetObjects { get; private set; } = new List<GameObject>();
     public List<GadgetBase> gadgets { get; private set; } = new List<GadgetBase>();
     public mainWeaponData.GunType gunType { get; private set; }
     [SerializeField]
@@ -16,7 +17,7 @@ public class Inventory : MonoBehaviour
     [SerializeField]
     private GameObject debugMainWeapon;
     [SerializeField]
-    private List<GadgetBase> debugGadgets = new List<GadgetBase>();
+    private List<GameObject> debugGadgets = new List<GameObject>();
 
     private void Awake()
     {
@@ -28,14 +29,16 @@ public class Inventory : MonoBehaviour
             if (mainWeapon != null)
                 gunType = mainWeapon.GetComponent<Gun>().GetMainWeaponData().gunType;
         }
+        /*
         else
         {
-            if(debugGadgets.Count >= 0)
+            if(debugGadgets.Count > 0)
             {
                 foreach (GadgetBase gadgetBase in debugGadgets)
                     gadgets.Add(Instantiate(gadgetBase.gameObject, gadgetHolder).GetComponent<GadgetBase>());
             }
         }
+        */
     }
     private void Start()
     {
@@ -55,6 +58,36 @@ public class Inventory : MonoBehaviour
 
         if(mainWeapon != null)
             gunType = mainWeapon.GetComponent<Gun>().GetMainWeaponData().gunType;
+    }
+
+    public void SetGadget()
+    {
+        if(gameManager.GameManager != null)
+        {
+            if (gameManager.GameManager.gadgetObjects.Count > 0)
+            {
+
+            }
+            else if (debugGadgets.Count > 0)
+                SetDebugGadget();
+        }
+        else if(debugGadgets.Count > 0)
+        {
+            SetDebugGadget();                
+        }
+    }
+
+    private void SetDebugGadget()
+    {
+        foreach (GameObject gadgetObject in debugGadgets)
+        {
+            gadgetObjects.Add(Instantiate(gadgetObject, gadgetHolder));
+        }
+
+        foreach (GameObject gadgetObject in gadgetObjects)
+        {
+            gadgets.Add(gadgetObject.GetComponent<GadgetBase>());
+        }
     }
 
     /*

--- a/Assets/_Script/Player/PlayerFiniteState/FunSearch.cs
+++ b/Assets/_Script/Player/PlayerFiniteState/FunSearch.cs
@@ -40,6 +40,16 @@ public class FunSearch : MonoBehaviour
                             addEnemyList(enemy);
 
                     }
+                    else if (throwObject != null)
+                    {
+                        if (hit.collider.gameObject == throwObject)
+                        {
+                            SetShow(other.gameObject);
+                            EnemyControllerBase enemy = other.gameObject.GetComponent<EnemyControllerBase>();
+                            if (enemy != null)
+                                addEnemyList(enemy);
+                        }
+                    }
                     else
                     {
                         //ターゲットとプレイヤーの間に別のオブジェクトが入った場合

--- a/Assets/_Script/Player/PlayerFiniteState/PlayerController.cs
+++ b/Assets/_Script/Player/PlayerFiniteState/PlayerController.cs
@@ -100,6 +100,7 @@ public class PlayerController : MonoBehaviour
         search = GetComponentInChildren<FunSearch>();
 
         Inventory.SetMainWeapon();
+        Inventory.SetGadget();
         GameObject setMainWeapon = null;
         switch (Inventory.gunType) 
         {

--- a/Assets/_Script/Player/PlayerGadget/DoorScope.cs
+++ b/Assets/_Script/Player/PlayerGadget/DoorScope.cs
@@ -11,6 +11,7 @@ public class DoorScope : GadgetBase
     private GameObject mainCamera;
     private GameObject doorObj;
     private Vector3 cameraPos;
+    private Vector3 cameraRot;
 
     private doorVariable doorVariable;
     public override void UseGadget()
@@ -35,9 +36,11 @@ public class DoorScope : GadgetBase
             return;
         }
 
-        cameraPos = doorVariable.doorScopeCenterPos;
+        cameraPos = doorVariable.doorCameraPos.transform.position;
+        cameraRot = doorVariable.GetDoorScopeAngle(player.transform.position).normalized;
         //subCamera.transform.position = transform.InverseTransformPoint(cameraPos);
         subCamera.transform.position = cameraPos;
+        subCamera.transform.LookAt(cameraPos + cameraRot);
         player.search.SetThrowObject(doorObj);
     }
     public override void EndGadget()

--- a/Assets/_Script/Singleton/gameManager.cs
+++ b/Assets/_Script/Singleton/gameManager.cs
@@ -42,6 +42,7 @@ public class gameManager  : MonoBehaviour
 
     public Gun gun { get; private set; }
     public nextSetGun setGun;
+    public List<GameObject> gadgetObjects = new List<GameObject>();
     private float score;
 
     private int maxEnemy;

--- a/Assets/doorVariable.cs
+++ b/Assets/doorVariable.cs
@@ -4,11 +4,30 @@ using UnityEngine;
 
 public class doorVariable : MonoBehaviour
 {
-    public Vector3 doorScopeCenterPos;
+    public GameObject doorCameraPos;
+    public bool playerRight;
 
-    private void Start()
+    public void Start()
     {
-        //doorScopeCenterPos = transform.TransformPoint(transform.position);
-        doorScopeCenterPos += transform.position;
+        playerRight = false;
+    }
+
+    public Vector3 GetDoorScopeAngle(Vector3 ppos)
+    {
+        Vector3 ret = new Vector3(0, 0, 0);
+        if(playerRight)
+        {
+            ret = doorCameraPos.transform.right * -1;
+        }
+        else
+        {
+            ret = doorCameraPos.transform.right;
+        }
+        return ret;
+    }
+
+    public void SetPlayerRight(bool flg)
+    {
+        playerRight = flg;
     }
 }

--- a/Assets/prefab/Door/Wall Door.prefab
+++ b/Assets/prefab/Door/Wall Door.prefab
@@ -1,5 +1,36 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &740264466
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 740264467}
+  m_Layer: 11
+  m_Name: doorScopePos
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &740264467
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 740264466}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 3.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8367886754899993257}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &901024453
 GameObject:
   m_ObjectHideFlags: 0
@@ -45,6 +76,65 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 49198541a4beed14782af70bcbcbe97a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &964792927
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 964792928}
+  - component: {fileID: 964792930}
+  - component: {fileID: 964792929}
+  m_Layer: 11
+  m_Name: doorRightCol
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &964792928
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 964792927}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 3.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8367886754899993257}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &964792930
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 964792927}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 0.281662, z: 7.024886}
+  m_Center: {x: 0.61, y: -0.3612032, z: -0.32156038}
+--- !u!114 &964792929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 964792927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fb099513da30deb448ecdf83ac0fa43d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  doorVar: {fileID: 1497331635}
 --- !u!1 &1848830780
 GameObject:
   m_ObjectHideFlags: 0
@@ -340,6 +430,7 @@ GameObject:
   - component: {fileID: 7095411839144558894}
   - component: {fileID: 7095411839144558892}
   - component: {fileID: 1497331632}
+  - component: {fileID: 1497331635}
   m_Layer: 11
   m_Name: Wall Door
   m_TagString: interact
@@ -362,6 +453,8 @@ Transform:
   - {fileID: 2091471192368752828}
   - {fileID: 8797286960433608355}
   - {fileID: 901024454}
+  - {fileID: 740264467}
+  - {fileID: 964792928}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -412,3 +505,17 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 0.43903348, y: 9.983421, z: 6.111888}
   m_Center: {x: 0.016490236, y: 4.063895, z: 3.0112958}
+--- !u!114 &1497331635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4790683710122119354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfe1edbd78b9fe64abe68a6b856e3782, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  doorCameraPos: {fileID: 740264466}
+  playerRight: 0

--- a/Assets/prefab/Player.prefab
+++ b/Assets/prefab/Player.prefab
@@ -552,7 +552,7 @@ RectTransform:
   - {fileID: 684213531}
   - {fileID: 351765054}
   m_Father: {fileID: 5651910625854211475}
-  m_RootOrder: 7
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -910,6 +910,37 @@ Light:
   m_UseViewFrustumForShadowCasterCull: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+--- !u!1 &1787966133
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1787966134}
+  m_Layer: 9
+  m_Name: GadgetHolder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1787966134
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1787966133}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5651910625854211475}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1906365560
 GameObject:
   m_ObjectHideFlags: 0
@@ -988,7 +1019,7 @@ RectTransform:
   - {fileID: 407066873}
   - {fileID: 671267297}
   m_Father: {fileID: 5651910625854211475}
-  m_RootOrder: 8
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1367,6 +1398,7 @@ Transform:
   - {fileID: 700237662}
   - {fileID: 1079565025}
   - {fileID: 1730620358}
+  - {fileID: 1787966134}
   - {fileID: 933417229}
   - {fileID: 1998788562}
   m_Father: {fileID: 0}
@@ -3645,7 +3677,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPlayer: 1
+  gadgetHolder: {fileID: 1787966134}
   debugMainWeapon: {fileID: 2606139686633315723, guid: 710b51e9bea667242b9464a495ed30a0, type: 3}
+  debugGadgets:
+  - {fileID: 8371366597903373672, guid: 34b1620bf5ea37d458482d9b02fbfba5, type: 3}
 --- !u!1 &7384495092277542840
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
ガジェット
・DoorScopeの作成
・プレイヤーの位置によってDoorScopeを使った時のカメラのポジションと向きを変更
・ゲームマネージャーにガジェットがセットされている時はそちらをセットするように変更
・ゲームマネージャーにガジェットがセットされていない時インベントリにdebugGadgetがセットされていればそちらをセットするように変更 ・ドアスコープを使った時、ドア越しに敵が表示されるように変更

ゲームマネージャー
・ガジェットのリストを追加

ドア
・DoorSearchPlayerRightスクリプトの追加
・閉じているドアに対してプレイヤーが右にいるか左にいるかの判定
・doorVariableにGetDoorScopeAngle関数の追加
ガジェットのカメラが向く方向を返す